### PR TITLE
[TASK] set dependency to EXT:templavoilaplus to allow dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "typo3/cms-core": "^8.7.0 || ^9.5.0 || ^10.4.0 || ^11.5.0",
         "typo3/cms-fluid": "^8.7.0 || ^9.5.0 || ^10.4.0 || ^11.5.0",
-        "templavoilaplus/templavoilaplus": "^8.0.4",
+        "templavoilaplus/templavoilaplus": "^8.0.4 || *@dev",
         "php": "^7.2"
     },
     "autoload": {


### PR DESCRIPTION
This would make it easier to install this in conjunction with a TVP dev-main, while still not hurting any projects (as long as they have a explicit EXT:templavoilaplus dependency, which they should have)